### PR TITLE
Reuse

### DIFF
--- a/lib/macaca-ios.js
+++ b/lib/macaca-ios.js
@@ -29,6 +29,8 @@ const WEBVIEW = 'WEBVIEW';
 const NATIVE = 'NATIVE_APP';
 const WEBVIEW_PREFIX = `${WEBVIEW}_`;
 
+const UNINSTALL_APP = 1; // uninstall app flag
+
 class IOS extends DriverBase {
   constructor() {
     super();
@@ -131,17 +133,32 @@ IOS.prototype.initSimulator = function *() {
   logger.debug(`Get available devices ${JSON.stringify(availableDevices)}`);
 
   const deviceString = this.args.deviceName;
+
   _.each(availableDevices, device => {
-    if (!!~device.name.indexOf(deviceString)) {
+    if (device.name === deviceString) {
       matchedDevice = device;
     }
   });
+
+  if (!matchedDevice) {
+    throw new Error(`Device ${deviceString} is not available!`);
+  }
+
   return new Simulator({
     deviceId: matchedDevice.udid
   });
 };
 
 IOS.prototype.startSimulator = function *() {
+
+  const isBooted = yield this.sim.isBooted();
+  
+  if (this.args.reuse && isBooted) {
+    if (UNINSTALL_APP & this.args.reuse) {
+      this.sim.uninstall(this.bundleId);
+    }
+    return;
+  }
 
   try {
     yield Simulator.killAll();
@@ -155,7 +172,10 @@ IOS.prototype.startSimulator = function *() {
     logger.debug(`Shutdown simulator ${this.sim.deviceId} failed ${e}`);
   }
 
-  yield this.sim.erase();
+  if (!this.args.reuse) {
+    yield this.sim.erase();
+  }
+
   yield this.sim.open();
 
   yield _.retry(() => {
@@ -172,7 +192,9 @@ IOS.prototype.startSimulator = function *() {
     });
   }, 3000, 10);
 
-  yield this.sim.install(this.args.app);
+  if (UNINSTALL_APP & this.args.reuse) {
+    this.sim.uninstall(this.bundleId);
+  }
 };
 
 IOS.prototype.getDeviceString = function() {
@@ -190,7 +212,7 @@ IOS.prototype.stopDevice = function *() {
     this.remote.stop();
   }
 
-  if (this.sim) {
+  if (this.sim && !this.args.reuse) {
     try {
       yield this.sim.shutdown();
     } catch(e) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macaca-ios",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "macaca-ios",
   "keywords": [
     "macaca",


### PR DESCRIPTION
Add flag "reuse" to keep simulator alive during testing.
reuse:
- 0 (default): Erase the simulator and install the app.
- 1: Keep the simulator open and reinstall the app.
- 2: Keep the simulator and app after testing.
